### PR TITLE
Add Langflow demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 - 👋 Hi, I’m @Quemener-ai
 - 👀 I’m interested in innovation by ai
 - 🌱 I’m currently learning langflow
-- 💞️ I’m looking to collaborate on ai an synthetic persona 
-- 📫 How to reach me by mail
-- 😄 Pronouns: ...
+- 💞 I’m looking to collaborate on ai an synthetic persona
+- 💋 How to reach me by mail
+- 😀 Pronouns: ...
 - ⚡ Fun fact: ...
 
-<!---
-Quemener-ai/Quemener-ai is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## Langflow example
+
+This repository includes a small demonstration script: `langflow_demo.py`.
+To try it out:
+
+1. Install the required packages:
+   ```bash
+   pip install langflow langchain
+   ```
+2. Create or download a flow definition, for example `hello_flow.json`.
+3. Run the script with the path to your flow file:
+   ```bash
+   python langflow_demo.py hello_flow.json
+   ```
+
+The script loads the flow and runs it with a sample input.

--- a/langflow_demo.py
+++ b/langflow_demo.py
@@ -1,0 +1,14 @@
+"""Minimal example to run a Langflow flow from a JSON file."""
+import sys
+from langflow import load_flow_from_json
+
+def main(path: str) -> None:
+    flow = load_flow_from_json(path)
+    result = flow({"text": "Bonjour"})
+    print(result)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python langflow_demo.py <flow.json>")
+    else:
+        main(sys.argv[1])


### PR DESCRIPTION
## Summary
- add `langflow_demo.py` demonstrating how to load and run a flow
- expand README with instructions on installing Langflow and using the demo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68444940867c832aa6ed214ac4e106dd